### PR TITLE
replace logo in docu with new COMIT logo from notion

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -11,7 +11,7 @@ module.exports = {
       title: 'Developer Hub',
       logo: {
         alt: 'COMIT',
-        src: 'img/logo.svg',
+        src: 'img/logo_white-rect.svg',
       },
       links: [
         {to: 'docs/getting-started/create-comit-app', label: 'Docs', position: 'left'},

--- a/static/img/logo_white-rect.svg
+++ b/static/img/logo_white-rect.svg
@@ -13,6 +13,7 @@
                         gradientTransform="translate(490.13 -435.74) rotate(45)" xlink:href="#linear-gradient"/>
     </defs>
     <title>COMITspellout_screen</title>
+    <rect x="0" width="100%" height="100%" rx="200" fill="white"/>
     <path class="cls-1"
           d="M598.3,629.82c-163.65-142.49-163.65-369.62,0-512.11l35.34,25c-71.29,71.25-107.25,148-107.25,231.4s36,160.15,107.25,231.4Z"/>
     <path class="cls-1"


### PR DESCRIPTION
- add svg without background (logo.svg)
- add svg with white-round-corner-rect (logo_write-rect.svg)
- configure white rect one for navbar (so one can see in dark mode)

Result (dark mode):
![image](https://user-images.githubusercontent.com/5557790/73808284-760f7080-4823-11ea-955f-cb433bb6679b.png)
