### PR TITLE
Configure browser icon for static HTML page

### DIFF
--- a/static/index.html
+++ b/static/index.html
@@ -8,6 +8,7 @@
 
     <link rel="stylesheet" href="css/bootstrap.min.css" type="text/css">
     <link rel="stylesheet" href="css/comit.css" type="text/css">
+    <link rel="shortcut icon" type="image/x-icon" href="img/favicon.ico"/>
     <title>:: COMIT ::</title>
     <!-- Global site tag (gtag.js) - Google Analytics -->
     <script async src="https://www.googletagmanager.com/gtag/js?id=G-RQEDN1PVTD"></script>


### PR DESCRIPTION
This is a quickfix, looks like the favicon is displayed correctly on the static page now.

![image](https://user-images.githubusercontent.com/5557790/75125807-224dc400-570b-11ea-903a-2a5ada6a4991.png)

(Fixed this because on some social media, like youtube, the logo for links is pulled from the favicon it seems.)