### PR TITLE
Add getting-started section to the vision blogpost

### DIFF
--- a/blog/2019-12-05-2020-COMIT-goals.md
+++ b/blog/2019-12-05-2020-COMIT-goals.md
@@ -86,7 +86,7 @@ If you want to reach out to us, drop us a mail at `hello (at) coblox.tech` or sa
 
 ## Getting Started - Build your first COMIT app
 
-COMIT is written by developers for developers. 
+COMIT is written with ♥️ by developers for developers. 
 The COMIT protocol is completely open-source so anyone is able to use the power of atomic swaps in their application.
 
 The COMIT team is working hard on making getting started with COMIT a piece of cake. 

--- a/blog/2019-12-05-2020-COMIT-goals.md
+++ b/blog/2019-12-05-2020-COMIT-goals.md
@@ -84,6 +84,13 @@ We appreciate any help or input on the protocol and tools we build: [COMIT on Gi
 You can use COMIT today to start building the cornerstones for the future: [Examples and getting started](https://github.com/comit-network/create-comit-app/). 
 If you want to reach out to us, drop us a mail at `hello (at) coblox.tech` or say hi on our [gitter](https://gitter.im/comit-network/community) 
 
+## Getting Started - Build your first COMIT app
+
+COMIT is written by developers for developers. 
+The COMIT protocol is completely open-source so anyone is able to use the power of atomic swaps in their application.
+
+The COMIT team is working hard on making getting started with COMIT a piece of cake. 
+We recommend getting started by reading the [Getting Started section of the COMIT documentation](https://comit.network/docs/getting-started/create-comit-app/). 
 
 Cheers,
 [Philipp](https://twitter.com/bonomat) and the [COMIT Team](https://twitter.com/comit_network) 💪


### PR DESCRIPTION
we want to link that blogpost on the new start page. Adding the getting started section helps users move on after reading through it. 