### PR TITLE
Classic presets already has gtag plugin activated

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -7,6 +7,9 @@ module.exports = {
   organizationName: 'coblox', // Usually your GitHub org/user name.
   projectName: 'comit-network', // Usually your repo name.
   themeConfig: {
+    gtag: {
+      trackingID: 'G-RQEDN1PVTD',
+    },
     navbar: {
       title: 'Developer Hub',
       logo: {
@@ -69,9 +72,6 @@ module.exports = {
         },
         theme: {
           customCss: require.resolve('./src/css/custom.css'),
-          gtag: {
-            trackingID: 'G-RQEDN1PVTD',
-          },
         },
         blog: {
           feedOptions: {

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -6,11 +6,7 @@ module.exports = {
   favicon: 'img/favicon.ico',
   organizationName: 'coblox', // Usually your GitHub org/user name.
   projectName: 'comit-network', // Usually your repo name.
-  plugins: ['@docusaurus/plugin-google-gtag'],
   themeConfig: {
-    gtag: {
-      trackingID: 'G-RQEDN1PVTD',
-    },
     navbar: {
       title: 'Developer Hub',
       logo: {
@@ -73,6 +69,9 @@ module.exports = {
         },
         theme: {
           customCss: require.resolve('./src/css/custom.css'),
+          gtag: {
+            trackingID: 'G-RQEDN1PVTD',
+          },
         },
         blog: {
           feedOptions: {


### PR DESCRIPTION
Move the gtag configuration into the presets config.
According to the [documentation for the `classic` preset](https://v2.docusaurus.io/docs/presets#docusauruspreset-classic) it should have the same effect. We have that preset set in the config.