### PR TITLE
Use a relative link to link to the blog

### DIFF
--- a/static/index.html
+++ b/static/index.html
@@ -56,7 +56,7 @@
                 </li>
                 <li class="mr-10  pr-3">
                     <a class="inline-block rounded-full hover:bg-pacific-blue py-2 px-4"
-                       href="https://comit.network/blog/">
+                       href="blog/">
                         Blog
                     </a>
                 </li>


### PR DESCRIPTION
The blog is on the same domain, we don't need an absolute link.