### PR TITLE
Replace alpha release download link with Matrix link

### DIFF
--- a/static/index.html
+++ b/static/index.html
@@ -71,8 +71,8 @@
                 COMIT is an open protocol<br>facilitating trustless<br>cross-blockchain applications
             </p>
             <a class="btn mx-auto md:ml-0 mt-17 text-6xl md:text-h3 md:mt-7 h-32 md:h-16 bg-pacific-blue px-7"
-               href="https://github.com/comit-network/ambrosia/releases">
-                Download Alpha Release
+               href="https://app.element.io/#/room/#comit:matrix.org">
+                Join us on Matrix
             </a>
         </div>
     </div>


### PR DESCRIPTION
This basically reverts commit d12653156c2b0ee04f1acf3b6ad18e4278e12c8b

Note: Instead of removing the commit (as described e.g. here https://sethrobertson.github.io/GitFixUm/fixup.html#remove_deep) I went for another commit on top to avoid rebase on open PRs and keep the history intact. 

If you prefer removing the commit let me know :)