### PR TITLE
Update the wording to remove create-comit-app and sdk

### DIFF
--- a/static/index.html
+++ b/static/index.html
@@ -135,31 +135,32 @@
             <img class="float-right w-92 md:w-33 md:pt-20" src="img/case.svg" alt="OPEN DEVELOPER CENTRIC TOOLS">
         </div>
         <div class="text-left">
-            <h3>OPEN DEVELOPER <br>CENTRIC TOOLS</h3>
+            <h3>CLEAN CODE</h3>
             <p class="md:pt-4 ">
-                Use <strong>create-comit-app</strong> to spin-up a<br class="hidden md:block">
-                development environment. The Javascript SDK<br class="hidden md:block">
-                allows simple usage of COMIT’s powerful API.
+                We love writing <strong>quality code</strong> <br class="hidden md:block">
+                tested end-to-end. <br class="hidden md:block">
+                Check out the projects <br class="hidden md:block">
+                on GitHub!
             </p>
-<!--            <a class="btn h-40 md:h-16 w-92 md:w-54 mt-17 md:mt-7 bg-klein-blue"-->
-<!--               href="https://comit.network/docs/getting-started/create-comit-app">-->
-<!--                Get Started-->
-<!--            </a>-->
+            <a class="btn h-40 md:h-16 w-92 md:w-54 mt-17 md:mt-7 bg-klein-blue"
+               href="https://github.com/comit-network/">
+                Give me code!
+            </a>
         </div>
     </div>
     <div class="grid grid-cols-2 pt-66 md:pt-28">
         <div class="text-right">
-            <h3>STANDARDIZED ATOMIC<br>SWAP PROTOCOLS</h3>
+            <h3>CLEAN PROTOCOLS</h3>
             <p class="md:pt-4">
                 Use our <strong>well-defined cryptographic<br class="hidden md:block">
                 protocols</strong> - HTLCs and Scriptless<br class="hidden md:block">
                 Scripts - to build trustless solutions<br class="hidden md:block">
                 powered by COMIT.
             </p>
-<!--            <a class="btn h-40 md:h-16 w-184 md:w-84 mr-0 ml-auto mt-17 md:mt-7 bg-klein-blue"-->
-<!--               href="https://github.com/comit-network/rfcs">-->
-<!--                Check Out The Full Specs-->
-<!--            </a>-->
+            <a class="btn h-40 md:h-16 w-92 md:w-54 mr-0 ml-auto mt-17 md:mt-7 bg-klein-blue"
+               href="https://app.element.io/#/room/#comit:matrix.org">
+                Get in touch!
+            </a>
         </div>
         <div class="pl-40 md:pl-10 my-auto ">
             <img class="float-left w-84 md:w-26 md:pt-20" src="img/note.svg" alt="STANDARDIZED ATOMIC SWAP PROTOCOLS">


### PR DESCRIPTION
Gave it a shot. 
I brought the buttons under the text back because it look better. Actions point to GitHub and Matrix:

![image](https://user-images.githubusercontent.com/5557790/102581399-9652d000-4154-11eb-8a40-e5be92c08938.png)
