### PR TITLE
We should have the mailing list more present

### DIFF
--- a/static/img/mailinglist-icon.svg
+++ b/static/img/mailinglist-icon.svg
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg version="1.1" viewBox="0 0 42 42" xmlns="http://www.w3.org/2000/svg" xmlns:cc="http://creativecommons.org/ns#" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+ <metadata>
+  <rdf:RDF>
+   <cc:Work rdf:about="">
+    <dc:format>image/svg+xml</dc:format>
+    <dc:type rdf:resource="http://purl.org/dc/dcmitype/StillImage"/>
+    <dc:title>mailto-icon</dc:title>
+   </cc:Work>
+  </rdf:RDF>
+ </metadata>
+ <defs>
+  <style>.cls-1{fill:#fff;}.cls-2{fill:#052a9f;}</style>
+ </defs>
+ <title>mailto-icon</title>
+ <g data-name="Слой 2">
+  <g id="content">
+   <path class="cls-1" d="M21,42A21,21,0,1,0,0,21,21,21,0,0,0,21,42"/>
+   <path class="cls-2" d="M20,24.25,7.25,13.05c0-1.8,1.36-1.88,1.36-1.88H33.39s1.36.08,1.36,1.88L22.06,24.25a3.21,3.21,0,0,1-.34.14h0a1.93,1.93,0,0,1-.69.12,1.88,1.88,0,0,1-.68-.12h0a2.36,2.36,0,0,1-.34-.14Zm1,2.5a3,3,0,0,1-1.9-.84C17.67,24.64,7.25,15.24,7.25,15.24v14a1.54,1.54,0,0,0,1.6,1.56h24.3a1.54,1.54,0,0,0,1.6-1.56v-14s-10.36,9.4-11.82,10.67a3,3,0,0,1-1.9.84Z"/>
+  </g>
+ </g>
+ <rect x="12.923" y="20.533" width="16.226" height="10.267" ry="1.041" fill="#fff" fill-opacity=".99048" stroke-opacity="0"/>
+ <g fill="#052a9f" stroke-opacity="0">
+  <rect x="17.805" y="22.185" width="9.6923" height="1.9385" ry=".96923"/>
+  <circle cx="16.01" cy="23.19" r="1.0769"/>
+  <rect x="17.769" y="24.913" width="9.6923" height="1.9385" ry=".96923"/>
+  <circle cx="15.974" cy="25.918" r="1.0769"/>
+  <rect x="17.769" y="27.641" width="9.6923" height="1.9385" ry=".96923"/>
+  <circle cx="15.974" cy="28.646" r="1.0769"/>
+ </g>
+</svg>

--- a/static/index.html
+++ b/static/index.html
@@ -50,6 +50,12 @@
                 </li>
                 <li class="mr-20 ">
                     <a class="inline-block rounded-full hover:bg-pacific-blue py-2 px-4"
+                       href="https://lists.comit.network/mailman/listinfo/comit-dev">
+                        Mailing List
+                    </a>
+                </li>
+                <li class="mr-20 ">
+                    <a class="inline-block rounded-full hover:bg-pacific-blue py-2 px-4"
                        href="https://github.com/comit-network/">
                         GitHub
                     </a>
@@ -244,10 +250,10 @@
                 ers build multi-currency wallets, multi-hop swaps and any other<br class="hidden md:block">
                 solution where anonymity and privacy matter.
             </p>
-<!--            <a class="btn h-40 md:h-16 px-12 md:px-8  mt-17 md:mt-7 bg-klein-blue"-->
-<!--               href="https://comit.network/docs/comit-protocol/comit-protocol-stack">-->
-<!--                Discover For Yourself-->
-<!--            </a>-->
+            <a class="btn h-40 md:h-16 px-12 md:px-8  mt-17 md:mt-7 bg-klein-blue"
+               href="https://lists.comit.network/mailman/listinfo/comit-dev">
+                Join the Discussion
+            </a>
         </div>
     </div>
 </div>
@@ -380,6 +386,8 @@
             <div class="text-center mb-0 mt-auto">
                 <a class="inline-block w-22 md:w-9" href="https://app.element.io/#/room/#comit:matrix.org"><img
                         src="img/element-icon.svg" alt="Element"></a>
+                <a class="inline-block w-22 md:w-9" href="https://lists.comit.network/mailman/listinfo/comit-dev"><img
+                        src="img/mailinglist-icon.svg" alt="MailingList"></a>
                 <a class="inline-block w-22 md:w-9" href="https://github.com/comit-network"><img
                         src="img/github-icon.svg" alt="GitHub"></a>
                 <a class="inline-block w-22 md:w-9" href="https://twitter.com/comit_network"><img


### PR DESCRIPTION
By now the mailing list setup has proven to be something we will use for longer,
so we should add it more presently to the homepage so that people can get in touch
and join the discussion.

This PR adds the link to the mailing list signup page to:

The header:
<img width="1434" alt="image" src="https://user-images.githubusercontent.com/5557790/102955980-4f395600-452b-11eb-9222-73f2c877bc74.png">


The `MORE THAN JUST A DEX` Section:
<img width="1435" alt="image" src="https://user-images.githubusercontent.com/5557790/102956013-6710da00-452b-11eb-8b94-1b153ef2abb2.png">


The footer:
<img width="1433" alt="image" src="https://user-images.githubusercontent.com/5557790/102956059-8445a880-452b-11eb-856d-d5727f13338a.png">
