### PR TITLE
Fix tracking script for static page

### DIFF
--- a/static/index.html
+++ b/static/index.html
@@ -10,7 +10,17 @@
 
     <title>COMIT Network</title>
     <!-- Global site tag (gtag.js) - Google Analytics -->
-    <script async src="https://www.googletagmanager.com/gtag/js?id=G-5RW3YGGP4Y"></script>
+    <!-- Global site tag (gtag.js) - Google Analytics -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=UA-187223132-1"></script>
+    <script>
+        window.dataLayer = window.dataLayer || [];
+        function gtag(){dataLayer.push(arguments);}
+        gtag('js', new Date());
+
+        gtag('config', 'UA-187223132-1');
+        gtag('config', 'G-5RW3YGGP4Y');
+    </script>
+
     <link rel="shortcut icon" type="image/x-icon" href="img/docusaurus/favicon.ico"/>
 
     <link rel="stylesheet" type="text/css" href="css/app.css?v=11">


### PR DESCRIPTION
Somehow events are not recorded for the static frontpage (for the docusaurus pages it is triggered correctly), so I am changing the script to test if it now properly triggers on the frontpage as well.